### PR TITLE
chore(nvim): add mini pairs rules

### DIFF
--- a/nvim/lua/plugins/mini_pairs.lua
+++ b/nvim/lua/plugins/mini_pairs.lua
@@ -9,17 +9,39 @@ local opts = {
     -- `<CR>`, `'` does not insert pair after a letter.
     -- Only parts of tables can be tweaked (others will use these defaults).
     mappings = {
-        ['('] = { action = 'open', pair = '()', neigh_pattern = '[^\\].' },
-        ['['] = { action = 'open', pair = '[]', neigh_pattern = '[^\\].' },
-        ['{'] = { action = 'open', pair = '{}', neigh_pattern = '[^\\].' },
+        ["("] = { action = "open", pair = "()", neigh_pattern = "[^\\]." },
+        ["["] = { action = "open", pair = "[]", neigh_pattern = "[^\\]." },
+        ["{"] = { action = "open", pair = "{}", neigh_pattern = "[^\\]." },
 
-        [')'] = { action = 'close', pair = '()', neigh_pattern = '[^\\].' },
-        [']'] = { action = 'close', pair = '[]', neigh_pattern = '[^\\].' },
-        ['}'] = { action = 'close', pair = '{}', neigh_pattern = '[^\\].' },
+        [")"] = { action = "close", pair = "()", neigh_pattern = "[^\\]." },
+        ["]"] = { action = "close", pair = "[]", neigh_pattern = "[^\\]." },
+        ["}"] = { action = "close", pair = "{}", neigh_pattern = "[^\\]." },
 
-        ['"'] = { action = 'closeopen', pair = '""', neigh_pattern = '[^\\].', register = { cr = false } },
-        ["'"] = { action = 'closeopen', pair = "''", neigh_pattern = '[^%a\\].', register = { cr = false } },
-        ['`'] = { action = 'closeopen', pair = '``', neigh_pattern = '[^\\].', register = { cr = false } },
+        ['"'] = {
+            action = "closeopen",
+            pair = '""',
+            neigh_pattern = "[^\\].",
+            register = { cr = false },
+        },
+        ["'"] = {
+            action = "closeopen",
+            pair = "''",
+            neigh_pattern = "[^%a\\].",
+            register = { cr = false },
+        },
+        ["`"] = {
+            action = "closeopen",
+            pair = "``",
+            neigh_pattern = "[^\\].",
+            register = { cr = false },
+        },
+		-- for Rust closures
+        ["|"] = {
+            action = "closeopen",
+            pair = "||",
+            neigh_pattern = "[^\\].",
+            register = { cr = false },
+        },
     },
 }
 
@@ -29,5 +51,5 @@ return {
     event = "InsertEnter",
     config = function()
         require("mini.pairs").setup(opts)
-    end
+    end,
 }


### PR DESCRIPTION
Consider moving to `autopairs` for more complicated scenarios.